### PR TITLE
refactor(sdk,dapp-kit,node): mm user data address abstraction

### DIFF
--- a/apps/node/src/moneymarket.ts
+++ b/apps/node/src/moneymarket.ts
@@ -8,8 +8,11 @@ import {
   type MoneyMarketConfig,
   Sodax,
   type SodaxConfig,
+  SonicSpokeProvider,
+  spokeChainConfig,
 } from '@sodax/sdk';
-import { SONIC_MAINNET_CHAIN_ID, type HubChainId } from '@sodax/types';
+import { Hex, SONIC_MAINNET_CHAIN_ID, type HubChainId } from '@sodax/types';
+import { EvmWalletProvider } from './wallet-providers/EvmWalletProvider.js';
 
 // load PK from .env
 const privateKey = process.env.EVM_PRIVATE_KEY;
@@ -27,6 +30,9 @@ const hubConfig = {
   hubRpcUrl: HUB_RPC_URL,
   chainConfig: getHubChainConfig(HUB_CHAIN_ID),
 } satisfies EvmHubProviderConfig;
+
+const spokeEvmWallet = new EvmWalletProvider(privateKey as Hex, HUB_CHAIN_ID, HUB_RPC_URL);
+const spokeProvider = new SonicSpokeProvider(spokeEvmWallet, spokeChainConfig[HUB_CHAIN_ID]);
 
 const sodax = new Sodax({
   moneyMarket: moneyMarketConfig,
@@ -107,7 +113,7 @@ async function displayFormattedData() {
   );
 
   // fetch user reserves
-  const userReserves = await sodax.moneyMarket.data.getUserReservesHumanized("0x0Ab764AB3816cD036Ea951bE973098510D8105A6");
+  const userReserves = await sodax.moneyMarket.data.getUserReservesHumanized(spokeProvider);
 
   // format user summary
   const userSummary = sodax.moneyMarket.data.formatUserSummary(

--- a/packages/dapp-kit/src/hooks/mm/useUserFormattedSummary.ts
+++ b/packages/dapp-kit/src/hooks/mm/useUserFormattedSummary.ts
@@ -36,10 +36,7 @@ export function useUserFormattedSummary(
       }
 
       // fetch reserves and hub wallet address
-      const [hubWalletAddress, reserves] = await Promise.all([
-        WalletAbstractionService.getUserHubWalletAddress(address, spokeProvider, sodax.hubProvider),
-        sodax.moneyMarket.data.getReservesHumanized(),
-      ]);
+      const reserves = await sodax.moneyMarket.data.getReservesHumanized();
 
       // format reserves
       const formattedReserves = sodax.moneyMarket.data.formatReservesUSD(
@@ -47,7 +44,7 @@ export function useUserFormattedSummary(
       );
 
       // fetch user reserves
-      const userReserves = await sodax.moneyMarket.data.getUserReservesHumanized(hubWalletAddress);
+      const userReserves = await sodax.moneyMarket.data.getUserReservesHumanized(spokeProvider);
 
       // format user summary
       return sodax.moneyMarket.data.formatUserSummary(

--- a/packages/dapp-kit/src/hooks/mm/useUserReservesData.ts
+++ b/packages/dapp-kit/src/hooks/mm/useUserReservesData.ts
@@ -35,13 +35,7 @@ export function useUserReservesData(
         return undefined;
       }
 
-      const hubWalletAddress = await WalletAbstractionService.getUserHubWalletAddress(
-        address,
-        spokeProvider,
-        sodax.hubProvider,
-      );
-
-      return await sodax.moneyMarket.data.getUserReservesData(hubWalletAddress);
+      return await sodax.moneyMarket.data.getUserReservesData(spokeProvider);
     },
     enabled: !!spokeChainId && !!address,
     refetchInterval,

--- a/packages/sdk/docs/MONEY_MARKET.md
+++ b/packages/sdk/docs/MONEY_MARKET.md
@@ -715,8 +715,8 @@ The SDK provides several methods to retrieve different types of data:
 - `getReserveNormalizedIncome(asset)` - Get normalized income for a specific asset
 
 #### User Data
-- `getUserReservesData(userAddress)` - Get raw user reserve data
-- `getUserReservesHumanized(userAddress)` - Get humanized user reserve data
+- `getUserReservesData(spokeProvider)` - Get raw user reserve data
+- `getUserReservesHumanized(spokeProvider)` - Get humanized user reserve data
 
 #### E-Mode Data
 - `getEModes()` - Get raw E-Mode data
@@ -749,7 +749,7 @@ const formattedReserves = sodax.moneyMarket.data.formatReservesUSD(
 );
 
 // Fetch user reserves data
-const userReserves = await sodax.moneyMarket.data.getUserReservesHumanized("0x..."); // wallet address
+const userReserves = await sodax.moneyMarket.data.getUserReservesHumanized(spokeProvider);
 
 // Format user summary with USD conversions
 const userSummary = sodax.moneyMarket.data.formatUserSummary(
@@ -771,8 +771,8 @@ First, retrieve the raw data from the blockchain:
 // Get humanized reserves data (normalized decimals)
 const reserves = await sodax.moneyMarket.data.getReservesHumanized();
 
-// Get user reserves data for a specific address
-const userReserves = await sodax.moneyMarket.data.getUserReservesHumanized(userAddress);
+// Get user reserves data for a specific spoke provider
+const userReserves = await sodax.moneyMarket.data.getUserReservesHumanized(spokeProvider);
 ```
 
 #### 2. Build Formatting Requests

--- a/packages/sdk/src/moneyMarket/LendingPoolService.ts
+++ b/packages/sdk/src/moneyMarket/LendingPoolService.ts
@@ -42,7 +42,7 @@ export class LendingPoolService {
 
   /**
    * Get the normalized income for a reserve
-   * @param asset The address of the asset
+   * @param asset - The address of the asset
    * @returns {Promise<bigint>} - Normalized income
    */
   async getReserveNormalizedIncome(asset: Address): Promise<bigint> {

--- a/packages/sdk/src/moneyMarket/UiPoolDataProviderService.ts
+++ b/packages/sdk/src/moneyMarket/UiPoolDataProviderService.ts
@@ -119,6 +119,10 @@ export class UiPoolDataProviderService implements UiPoolDataProviderInterface {
     });
   }
 
+  /**
+   * Get the reserves data humanized
+   * @returns {Promise<ReservesDataHumanized>} - The reserves data humanized
+   */
   public async getReservesHumanized(): Promise<ReservesDataHumanized> {
     const [reservesRaw, poolBaseCurrencyRaw] = await this.getReservesData();
 

--- a/packages/sdk/src/services/solver/SolverService.test.ts
+++ b/packages/sdk/src/services/solver/SolverService.test.ts
@@ -1,5 +1,3 @@
-import { WalletAbstractionService } from '@sodax/sdk';
-import type { Address } from 'viem';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   type CreateIntentParams,
@@ -38,7 +36,8 @@ import {
 import * as IntentRelayApiService from '../intentRelay/IntentRelayApiService.js';
 import { EvmWalletAbstraction } from '../hub/EvmWalletAbstraction.js';
 import { EvmSolverService } from './EvmSolverService.js';
-import { ARBITRUM_MAINNET_CHAIN_ID, BSC_MAINNET_CHAIN_ID, SONIC_MAINNET_CHAIN_ID } from '@sodax/types';
+import { WalletAbstractionService } from '../hub/WalletAbstractionService.js';
+import { ARBITRUM_MAINNET_CHAIN_ID, BSC_MAINNET_CHAIN_ID, SONIC_MAINNET_CHAIN_ID, type Address } from '@sodax/types';
 
 // Define a type for Intent with fee amount
 type IntentWithFee = Intent & FeeAmount;


### PR DESCRIPTION
## Description

Refactored money market user based data retrieval to accept spoke provider instead of address due to the confusion of which address to use (hub or spoke).

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run the unit tests
- [x] I only have one commit (if not, squash them into one commit).
- [x] I have a descriptive commit message that adheres to the [commit message guidelines](https://www.conventionalcommits.org/en/v1.0.0/)