### PR TITLE
feat: integrate user wallet address derivation

### DIFF
--- a/apps/demo/src/pages/money-market/page.tsx
+++ b/apps/demo/src/pages/money-market/page.tsx
@@ -3,17 +3,25 @@ import React from 'react';
 import { ChainSelector } from '@/components/shared/ChainSelector';
 import { SupplyAssetsList } from '@/components/mm/lists/SupplyAssetsList';
 import { Button } from '@/components/ui/button';
-import { useXAccount } from '@sodax/wallet-sdk';
+import { useWalletProvider, useXAccount } from '@sodax/wallet-sdk';
 import { useAppStore } from '@/zustand/useAppStore';
+import { useDeriveUserWalletAddress, useSpokeProvider } from '@sodax/dapp-kit';
 
 export default function MoneyMarketPage() {
   const { openWalletModal, selectedChainId, selectChainId } = useAppStore();
   const xAccount = useXAccount(selectedChainId);
 
+  const walletProvider = useWalletProvider(selectedChainId);
+  const spokeProvider = useSpokeProvider(selectedChainId, walletProvider);
+  const { data: walletAddressOnHub } = useDeriveUserWalletAddress(spokeProvider, xAccount?.address);
+
   return (
     <main className="">
       <div className="container mx-auto p-4 mt-10 space-y-4">
-        <ChainSelector selectedChainId={selectedChainId} selectChainId={selectChainId} />
+        <div className="flex items-center gap-2">
+          <ChainSelector selectedChainId={selectedChainId} selectChainId={selectChainId} />
+          <div className="text-sm">hub wallet address: {walletAddressOnHub}</div>
+        </div>
         {xAccount?.address ? (
           <SupplyAssetsList />
         ) : (

--- a/packages/dapp-kit/README.md
+++ b/packages/dapp-kit/README.md
@@ -32,6 +32,9 @@ dApp Kit is a collection of React components, hooks, and utilities designed to s
   - Get spoke chain provider (`useSpokeProvider`)
   - Get wallet provider (`useWalletProvider`)
 
+- Shared
+  - Derive user wallet address for hub abstraction (`useDeriveUserWalletAddress`)
+
 ## Installation
 
 ```bash
@@ -148,6 +151,24 @@ function TokenManagementComponent() {
   };
 }
 
+// Wallet Address Derivation
+import { useDeriveUserWalletAddress, useSpokeProvider } from '@sodax/dapp-kit';
+
+function WalletAddressComponent() {
+  const spokeProvider = useSpokeProvider(chainId, walletProvider);
+  
+  // Derive user wallet address for hub abstraction
+  const { data: derivedAddress, isLoading, error } = useDeriveUserWalletAddress(spokeProvider, userAddress);
+  
+  return (
+    <div>
+      {isLoading && <div>Deriving wallet address...</div>}
+      {error && <div>Error: {error.message}</div>}
+      {derivedAddress && <div>Derived Address: {derivedAddress}</div>}
+    </div>
+  );
+}
+
 // Swap Operations
 import { useQuote, useSwap, useStatus } from '@sodax/dapp-kit';
 
@@ -215,6 +236,7 @@ function SwapComponent() {
 #### Shared Hooks
 - [`useSodaxContext()`](./src/hooks/shared/useSodaxContext.ts) - Access Sodax context and configuration
 - [`useEstimateGas()`](./src/hooks/shared/useEstimateGas.ts) - Estimate gas costs for transactions
+- [`useDeriveUserWalletAddress()`](./src/hooks/shared/useDeriveUserWalletAddress.ts) - Derive user wallet address for hub abstraction
 
 
 ## Contributing

--- a/packages/dapp-kit/src/contexts/index.ts
+++ b/packages/dapp-kit/src/contexts/index.ts
@@ -1,11 +1,10 @@
 import { createContext } from 'react';
-import type { EvmHubProvider, Sodax } from '@sodax/sdk';
+import type { Sodax } from '@sodax/sdk';
 import type { RpcConfig } from '@/types';
 
 export interface SodaxContextType {
   sodax: Sodax;
   testnet: boolean;
-  hubProvider: EvmHubProvider | undefined;
   rpcConfig: RpcConfig;
 }
 

--- a/packages/dapp-kit/src/hooks/provider/useHubProvider.ts
+++ b/packages/dapp-kit/src/hooks/provider/useHubProvider.ts
@@ -1,8 +1,8 @@
 import type { EvmHubProvider } from '@sodax/sdk';
 import { useSodaxContext } from '../shared/useSodaxContext';
 
-export function useHubProvider(): EvmHubProvider | undefined {
-  const { hubProvider } = useSodaxContext();
+export function useHubProvider(): EvmHubProvider {
+  const { sodax } = useSodaxContext();
 
-  return hubProvider;
+  return sodax.hubProvider;
 }

--- a/packages/dapp-kit/src/hooks/shared/index.ts
+++ b/packages/dapp-kit/src/hooks/shared/index.ts
@@ -1,2 +1,3 @@
 export * from './useSodaxContext';
 export * from './useEstimateGas';
+export * from './useDeriveUserWalletAddress';

--- a/packages/dapp-kit/src/hooks/shared/useDeriveUserWalletAddress.ts
+++ b/packages/dapp-kit/src/hooks/shared/useDeriveUserWalletAddress.ts
@@ -1,0 +1,44 @@
+// packages/dapp-kit/src/hooks/shared/useDeriveUserWalletAddress.ts
+import { deriveUserWalletAddress, type SpokeProvider, type EvmHubProvider } from '@sodax/sdk';
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { useSodaxContext } from './useSodaxContext';
+import type { Address } from 'viem';
+
+/**
+ * Hook for deriving user wallet address for hub abstraction.
+ *
+ * This hook derives the user's abstracted wallet address for the hub chain.
+ * If the spoke chain is the same as the hub chain, it returns the original wallet address.
+ * Otherwise, it returns the abstracted wallet address for cross-chain operations.
+ *
+ * @param spokeProvider - The spoke provider instance for the origin chain
+ * @param walletAddress - Optional user wallet address on spoke chain. If not provided, will fetch from spokeProvider
+ * @returns A React Query result object containing:
+ *   - data: The derived user wallet address when available
+ *   - isLoading: Loading state indicator
+ *   - error: Any error that occurred during derivation
+ *
+ * @example
+ * ```typescript
+ * const { data: derivedAddress, isLoading, error } = useDeriveUserWalletAddress(spokeProvider, userAddress);
+ * ```
+ */
+export function useDeriveUserWalletAddress(
+  spokeProvider: SpokeProvider | undefined,
+  walletAddress?: string | undefined,
+): UseQueryResult<Address, Error> {
+  const { sodax } = useSodaxContext();
+
+  return useQuery({
+    queryKey: ['deriveUserWalletAddress', spokeProvider?.chainConfig.chain.id, walletAddress],
+    queryFn: async (): Promise<Address> => {
+      if (!spokeProvider) {
+        throw new Error('Spoke provider is required');
+      }
+
+      return await deriveUserWalletAddress(spokeProvider, sodax.hubProvider, walletAddress);
+    },
+    enabled: !!spokeProvider,
+    refetchInterval: false, // This is a deterministic operation, no need to refetch
+  });
+}

--- a/packages/dapp-kit/src/providers/SodaxProvider.tsx
+++ b/packages/dapp-kit/src/providers/SodaxProvider.tsx
@@ -1,7 +1,8 @@
 import type { ReactNode, ReactElement } from 'react';
-import { EvmHubProvider, getHubChainConfig, Sodax, type SodaxConfig } from '@sodax/sdk';
+import React from 'react';
+
+import { Sodax, type SodaxConfig } from '@sodax/sdk';
 import { SodaxContext } from '@/contexts';
-import React, { useMemo } from 'react';
 import type { RpcConfig } from '@/types';
 
 interface SodaxProviderProps {
@@ -14,20 +15,5 @@ interface SodaxProviderProps {
 export const SodaxProvider = ({ children, testnet = false, config, rpcConfig }: SodaxProviderProps): ReactElement => {
   const sodax = new Sodax(config);
 
-  const hubChainId = config?.hubProviderConfig?.chainConfig.chain.id;
-  const hubRpcUrl = config?.hubProviderConfig?.hubRpcUrl;
-
-  const hubProvider = useMemo(() => {
-    if (hubChainId && hubRpcUrl) {
-      const hubChainCfg = getHubChainConfig(hubChainId);
-
-      return new EvmHubProvider({
-        hubRpcUrl: hubRpcUrl,
-        chainConfig: hubChainCfg,
-      });
-    }
-    return undefined;
-  }, [hubChainId, hubRpcUrl]);
-
-  return <SodaxContext.Provider value={{ sodax, testnet, hubProvider, rpcConfig }}>{children}</SodaxContext.Provider>;
+  return <SodaxContext.Provider value={{ sodax, testnet, rpcConfig }}>{children}</SodaxContext.Provider>;
 };


### PR DESCRIPTION
- Added `useDeriveUserWalletAddress` to derive the user's wallet address in the Money Market page.
- Updated `useHubProvider` to return the hub provider from the `sodax` context instead of directly.
- Removed unused `EvmHubProvider` from the context and related components.
- Cleaned up imports and adjusted the `SodaxProvider` to reflect the changes in context structure.

## Description

Describe what have you done and which # issue does this PR closes.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the unit tests
- [ ] I only have one commit (if not, squash them into one commit).
- [ ] I have a descriptive commit message that adheres to the [commit message guidelines](https://www.conventionalcommits.org/en/v1.0.0/)